### PR TITLE
Fix NULL pointer given error with no argument

### DIFF
--- a/lib/lineprof.rb
+++ b/lib/lineprof.rb
@@ -18,7 +18,14 @@ class Lineprof
     private
 
     def caller_filename(caller_lines)
-      caller_lines.first.split(':').first || DEFAULT_PATTERN
+      filename = caller_lines.first.split(':').first
+
+      if filename
+        # Don't add \A because filename may not be an absolute path
+        /#{Regexp.escape(filename)}\z/
+      else
+        DEFAULT_PATTERN
+      end
     end
 
     def format(result)


### PR DESCRIPTION
It seems rblineprof requires regexp, not string.

```
$ bundle exec ruby example.rb
/app/lib/lineprof.rb:11:in `lineprof': NULL pointer given (ArgumentError)
        from /app/lib/lineprof.rb:11:in `profile'
        from example.rb:3:in `<main>'
```

I guess example.rb worked well at one time though, I can't find the cause.
It fails even with old rubies (2.2 ~ 2.5)

```ruby
$ cat a.rb
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'lineprof'
end

Lineprof.profile do
  sleep 0.001
end
```

```
$ docker run -v $PWD:/$PWD -w /$PWD ruby:2.2 ruby a.rb
/usr/local/bundle/gems/lineprof-0.1.1/lib/lineprof.rb:11:in `lineprof': NULL pointer given (ArgumentError)
        from /usr/local/bundle/gems/lineprof-0.1.1/lib/lineprof.rb:11:in `profile'
        from a.rb:9:in `<main>'
```