### PR TITLE
Use rack-lineprof 0.0.4

### DIFF
--- a/lineprof.gemspec
+++ b/lineprof.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rblineprof", "~> 0.3.6"
-  spec.add_dependency "rack-lineprof", "0.0.3"
+  spec.add_dependency "rack-lineprof", "0.0.4"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
## Why

I would like to use lineprof with an application that is heavily dependent on rack being at least version 2

## What

Until version 0.0.3 rack-lineprof was dependent on `~> rack 1.5` cf: https://github.com/kainosnoema/rack-lineprof/compare/v0.0.3...v0.0.4

I tested this locally with a small rails application and it seems to work, but let me know if you have concerns about incompatibilities :pray: 
